### PR TITLE
113 store has default status of pending at creation

### DIFF
--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -11,8 +11,6 @@ class StoresController < ApplicationController
 
   def create
     @store = current_user.stores.create(store_params)
-    @store.status = "pending"
-    @store.save
     flash[:notice] = {color: "green", message: "#{@store.title} has been submitted for review."}
     redirect_to root_path
   end

--- a/db/migrate/20160211010222_set_stores_default_status_to_pending.rb
+++ b/db/migrate/20160211010222_set_stores_default_status_to_pending.rb
@@ -1,0 +1,5 @@
+class SetStoresDefaultStatusToPending < ActiveRecord::Migration
+  def change
+    change_column_default(:stores, :status, 'pending')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160210023029) do
+ActiveRecord::Schema.define(version: 20160211010222) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,11 +77,11 @@ ActiveRecord::Schema.define(version: 20160210023029) do
   create_table "stores", force: :cascade do |t|
     t.string   "title"
     t.string   "description"
-    t.string   "status"
+    t.string   "status",         default: "pending"
     t.string   "image_url"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.text     "accreditations", default: [],              array: true
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
+    t.text     "accreditations", default: [],                     array: true
     t.string   "slug"
     t.integer  "user_id"
   end

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Store, type: :model do
+	it "is created with default status of 'pending'" do
+		store = Store.create(
+			title: "Store",
+			description: "Description",
+			image_url: "http://www.image_url.com",
+			accreditations: "['The Nature Conservancy']"
+		)
+
+		expect(store.status).to eq "pending"
+	end
+end


### PR DESCRIPTION
Creates model test. To pass, added migration to change default status of store to "pending," then removed lines in the store controller that set status to "pending" on creation.  Closes #113 
